### PR TITLE
fix pydantic error

### DIFF
--- a/yandex_chain/YandexGPT.py
+++ b/yandex_chain/YandexGPT.py
@@ -21,7 +21,7 @@ class YandexLLM(LLM):
     temperature : float = 1.0
     max_tokens : int = 1500
     sleep_interval : float = 1.0
-    retries = 3
+    retries : int = 3
     use_lite : bool = None
     model : YandexGPTModel = None
     instruction_text : str = None


### PR DESCRIPTION
Здравствуйте! При попытке использования с пакетом `langchain-community` сталкиваюсь с ошибкой: 
```pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `retries = 3`. All model fields require a type annotation; if `retries` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.```

Добавил пропущенный typehint.